### PR TITLE
Use String31 for bid and load unique identifiers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FullNetworkSystems"
 uuid = "877b7152-b508-43dc-81fb-72341a693988"
 authors = ["Invenia Technical Computing Corporation"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"

--- a/src/system.jl
+++ b/src/system.jl
@@ -23,6 +23,7 @@ end
 ###### Static Component Types ######
 const BusName = InlineString15
 const BranchName = InlineString31
+const BidName = InlineString31
 
 """
     $TYPEDEF
@@ -300,16 +301,16 @@ struct SystemDA <: System
     "`Dictionary` where the keys are bus names and the values are generator ids at that bus"
     gens_per_bus::Dictionary{BusName, Vector{Int}}
     "`Dictionary` where the keys are bus names and the values are increment bid ids at that bus"
-    incs_per_bus::Dictionary{BusName, Vector{String}}
+    incs_per_bus::Dictionary{BusName, Vector{BidName}}
     "`Dictionary` where the keys are bus names and the values are decrement bid ids at that bus"
-    decs_per_bus::Dictionary{BusName, Vector{String}}
+    decs_per_bus::Dictionary{BusName, Vector{BidName}}
     """
     `Dictionary` where the keys are bus names and the values are price sensitive demand bid
     ids at that bus
     """
-    psds_per_bus::Dictionary{BusName, Vector{String}}
+    psds_per_bus::Dictionary{BusName, Vector{BidName}}
     "`Dictionary` where the keys are bus names and the values are load ids at that bus"
-    loads_per_bus::Dictionary{BusName, Vector{String}}
+    loads_per_bus::Dictionary{BusName, Vector{BidName}}
 
     "Zones in the `System`, which will also include a `Zone` entry for the market wide zone"
     zones::Dictionary{Int, Zone}
@@ -362,7 +363,7 @@ struct SystemRT <: System
     "`Dictionary` where the keys are bus names and the values are generator ids at that bus"
     gens_per_bus::Dictionary{BusName, Vector{Int}}
     "`Dictionary` where the keys are bus names and the values are load ids at that bus"
-    loads_per_bus::Dictionary{BusName, Vector{String}}
+    loads_per_bus::Dictionary{BusName, Vector{BidName}}
 
     "Zones in the `System`, which will also include a `Zone` entry for the market wide zone"
     zones::Dictionary{Int, Zone}


### PR DESCRIPTION
In our simulations we use unique identifiers for bids and loads that are ~25 characters long.  It is probably worth storing these as `String31` as we do for branch names.