### PR TITLE
Make PTDF droppable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FullNetworkSystems"
 uuid = "877b7152-b508-43dc-81fb-72341a693988"
 authors = ["Invenia Technical Computing Corporation"]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"

--- a/src/system.jl
+++ b/src/system.jl
@@ -297,7 +297,7 @@ Subtype of a `System` for modelling the day-ahead market.
 Fields:
 $TYPEDFIELDS
 """
-struct SystemDA <: System
+mutable struct SystemDA <: System
     "`Dictionary` where the keys are bus names and the values are generator ids at that bus"
     gens_per_bus::Dictionary{BusName, Vector{Int}}
     "`Dictionary` where the keys are bus names and the values are increment bid ids at that bus"
@@ -330,7 +330,7 @@ struct SystemDA <: System
     Power transfer distribution factor of the system.  `KeyedArray` where the axis keys are
     `branch names x bus names`
     """
-    ptdf::KeyedArray{Float64, 2}
+    ptdf::Union{KeyedArray{Float64, 2}, Missing}
 
     # Generator related time series
     "Generator related time series data"
@@ -359,7 +359,7 @@ Subtype of a `System` for modelling the real-time market.
 Fields:
 $TYPEDFIELDS
 """
-struct SystemRT <: System
+mutable struct SystemRT <: System
     "`Dictionary` where the keys are bus names and the values are generator ids at that bus"
     gens_per_bus::Dictionary{BusName, Vector{Int}}
     "`Dictionary` where the keys are bus names and the values are load ids at that bus"
@@ -383,7 +383,7 @@ struct SystemRT <: System
     Power transfer distribution factor of the system.  `KeyedArray` where the axis keys are
     `branch names x bus names`
     """
-    ptdf::KeyedArray{Float64, 2}
+    ptdf::Union{KeyedArray{Float64, 2}, Missing}
 
     # Generator related time series
     "Generator related time series data"

--- a/test/system.jl
+++ b/test/system.jl
@@ -182,6 +182,10 @@
                 @test zero_bp == ["3"]
                 @test one_bp == String[] #unmonitored
                 @test two_bp == ["1", "4"]
+
+                # Check that we can remove the PTDF
+                system.ptdf = missing
+                @test system.ptdf === missing
             end
 
             @testset "SystemDA only accessors" begin


### PR DESCRIPTION
Closes https://github.com/invenia/FullNetworkSystems.jl/issues/11.

Makes System mutable and changes type of `ptdf` to allow it to be missing. 