### PR TITLE
Add `Base.@kwdef` to all system-related structs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FullNetworkSystems"
 uuid = "877b7152-b508-43dc-81fb-72341a693988"
 authors = ["Invenia Technical Computing Corporation"]
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"

--- a/src/system.jl
+++ b/src/system.jl
@@ -207,10 +207,16 @@ function Branch(;
     penalties,
     resistance,
     reactance,
-    is_transformer=false,
     tap=missing,
     angle=missing
 )
+    if ismissing(tap) && ismissing(angle)
+        is_transformer = false
+    elseif !ismissing(tap) && !ismissing(angle)
+        is_transformer = true
+    else
+        ArgumentError("Transformers must have non-missing values for both `tap` and `angle`. Got `tap=$tap, angle=$angle`.")
+    end
     return Branch(
         name,
         to_bus,

--- a/src/system.jl
+++ b/src/system.jl
@@ -1,6 +1,7 @@
 const MARKET_WIDE_ZONE = -9999
 const BidName = InlineString31
 const ZoneNum = Int64
+
 """
     $TYPEDEF
 
@@ -11,7 +12,7 @@ of 100MW.
 Fields:
 $TYPEDFIELDS
 """
-struct Zone
+Base.@kwdef struct Zone
     "Zone number"
     number::ZoneNum
     "Zonal regulation requirement (pu)"
@@ -33,7 +34,7 @@ series data).  Parameters given in `pu` assume a base power of 100MW.
 Fields:
 $TYPEDFIELDS
 """
-struct Generator
+Base.@kwdef struct Generator
     "Generator id/unit code"
     unit_code::UnitCode
     "Number of the zone the generator is located in"
@@ -66,7 +67,7 @@ Type for static bus attributes.
 Fields:
 $TYPEDFIELDS
 """
-struct Bus
+Base.@kwdef struct Bus
     "Bus name"
     name::BusName
     "Base voltage (kV)"
@@ -84,7 +85,7 @@ points which is why the `break_points` and `penalties` fields contain variable l
 Fields:
 $TYPEDFIELDS
 """
-struct Branch
+Base.@kwdef struct Branch
     "Branch long name"
     name::BranchName
     "Name of the bus the branch goes to"
@@ -206,7 +207,7 @@ Values given in `pu` assume a base power of 100MW.
 Fields:
 $TYPEDFIELDS
 """
-struct GeneratorTimeSeries
+Base.@kwdef struct GeneratorTimeSeries
     "Generation of the generator at the start of the time period (pu)"
     initial_generation::KeyedArray{Float64, 1}
     "Generator offer curves. `KeyedArray` where the axis keys are `generator names x datetimes`"
@@ -256,7 +257,7 @@ Generator status time series data needed for the day-ahead formulation.
 Fields:
 $TYPEDFIELDS
 """
-struct GeneratorStatusDA <: GeneratorStatus
+Base.@kwdef struct GeneratorStatusDA <: GeneratorStatus
     "Hours each generator has been at its current status at the start of the day"
     hours_at_status::KeyedArray{Float64, 1}
     "Flag indicating if the generator is available to be committed in each hour"
@@ -273,7 +274,7 @@ Generator status time series data needed for the real-time formulation.
 Fields:
 $TYPEDFIELDS
 """
-struct GeneratorStatusRT <: GeneratorStatus
+Base.@kwdef struct GeneratorStatusRT <: GeneratorStatus
     "Generator commitment status indicated by a `Bool`"
     status::KeyedArray{Bool, 2}
     "Generator regulation commitment status indicated by a `Bool`"
@@ -301,7 +302,7 @@ Subtype of a `System` for modelling the day-ahead market.
 Fields:
 $TYPEDFIELDS
 """
-mutable struct SystemDA <: System
+Base.@kwdef mutable struct SystemDA <: System
     "`Dictionary` where the keys are bus names and the values are generator ids at that bus"
     gens_per_bus::Dictionary{BusName, Vector{Int}}
     "`Dictionary` where the keys are bus names and the values are increment bid ids at that bus"
@@ -363,7 +364,7 @@ Subtype of a `System` for modelling the real-time market.
 Fields:
 $TYPEDFIELDS
 """
-mutable struct SystemRT <: System
+Base.@kwdef mutable struct SystemRT <: System
     "`Dictionary` where the keys are bus names and the values are generator ids at that bus"
     gens_per_bus::Dictionary{BusName, Vector{Int}}
     "`Dictionary` where the keys are bus names and the values are load ids at that bus"

--- a/src/system.jl
+++ b/src/system.jl
@@ -85,7 +85,7 @@ points which is why the `break_points` and `penalties` fields contain variable l
 Fields:
 $TYPEDFIELDS
 """
-Base.@kwdef struct Branch
+struct Branch
     "Branch long name"
     name::BranchName
     "Name of the bus the branch goes to"
@@ -140,7 +140,7 @@ function Branch(
     rate_b,
     is_monitored,
     break_points,
-    penalities,
+    penalties,
     resistance=0.0,
     reactance=0.0
 )
@@ -155,7 +155,7 @@ function Branch(
         rate_b,
         is_monitored,
         break_points,
-        penalities,
+        penalties,
         resistance,
         reactance,
         is_transformer,
@@ -172,7 +172,7 @@ function Branch(
     rate_b,
     is_monitored,
     break_points,
-    penalities,
+    penalties,
     resistance,
     reactance,
     tap::Float64,
@@ -187,7 +187,39 @@ function Branch(
         rate_b,
         is_monitored,
         break_points,
-        penalities,
+        penalties,
+        resistance,
+        reactance,
+        is_transformer,
+        tap,
+        angle
+    )
+end
+
+function Branch(;
+    name,
+    to_bus,
+    from_bus,
+    rate_a,
+    rate_b,
+    is_monitored,
+    break_points,
+    penalties,
+    resistance,
+    reactance,
+    is_transformer=false,
+    tap=missing,
+    angle=missing
+)
+    return Branch(
+        name,
+        to_bus,
+        from_bus,
+        rate_a,
+        rate_b,
+        is_monitored,
+        break_points,
+        penalties,
         resistance,
         reactance,
         is_transformer,

--- a/test/system.jl
+++ b/test/system.jl
@@ -170,7 +170,6 @@
                 rate_a=50.0,
                 rate_b=55.0,
                 is_monitored=true,
-                is_transformer=false,
                 break_points=(1.0, 2.0),
                 penalties=(3.0, 4.0),
                 resistance=1.0,
@@ -178,6 +177,7 @@
             )
             @test branch_kws isa Branch
             @test branch_kws.is_monitored
+            @test !branch_kws.is_transformer
 
             gen_ts_kws = GeneratorTimeSeries(
                 initial_generation=fake_vec_ts,

--- a/test/system.jl
+++ b/test/system.jl
@@ -136,6 +136,117 @@
         )
         @test rt_system isa SystemRT
 
+
+        @testset "Constructors using keywords" begin
+            zone_kws = Zone(
+                number=1, regulation=10.0, operating_reserve=20.0, good_utility=5.0
+            )
+            @test zone_kws isa Zone
+            @test zone.regulation == 10.0
+
+            generator_kws = Generator(
+                unit_code=1,
+                zone=1,
+                startup_cost=10.0,
+                shutdown_cost=5.0,
+                no_load_cost=1.0,
+                min_uptime=2.0,
+                min_downtime=1.0,
+                ramp_up=0.2,
+                ramp_down=0.4,
+                technology=:foo
+            )
+            @test generator_kws isa Generator
+            @test generator_kws.technology == :foo
+
+            bus_kws = Bus(name="foo", base_voltage=69.0)
+            @test bus_kws isa Bus
+            @test bus_kws.base_voltage == 69.0
+
+            branch_kws = Branch(
+                name="moo",
+                to_bus="foo1",
+                from_bus="foo2",
+                rate_a=50.0,
+                rate_b=55.0,
+                is_monitored=true,
+                break_points=(1.0, 2.0),
+                penalties=(3.0, 4.0),
+                resistance=1.0,
+                reactance=1.0
+            )
+            @test branch_kws isa Branch
+            @test branch_kws.is_monitored
+
+            gen_ts_kws = GeneratorTimeSeries(
+                initial_generation=fake_vec_ts,
+                offer_curve=fake_offer_ts,
+                regulation_min=fake_gen_ts,
+                regulation_max=fake_gen_ts,
+                pmin=fake_gen_ts,
+                pmax=fake_gen_ts,
+                asm_regulation=fake_services_ts,
+                asm_spin=fake_services_ts,
+                asm_sup_on=fake_services_ts,
+                asm_sup_off=fake_services_ts
+            )
+            @test gen_ts_kws isa GeneratorTimeSeries
+            @test gen_ts_kws.pmin == fake_gen_ts
+
+            da_gen_status_kws = GeneratorStatusDA(
+                hours_at_status=fake_vec_ts,
+                availability=fake_bool_ts,
+                must_run=fake_bool_ts
+            )
+            @test da_gen_status_kws isa GeneratorStatusDA
+            @test da_gen_status_kws.must_run == fake_bool_ts
+
+            rt_gen_status_kws = GeneratorStatusRT(
+                status=fake_bool_ts,
+                status_regulation=fake_bool_ts
+            )
+            @test rt_gen_status_kws isa GeneratorStatusRT
+            @test rt_gen_status_kws.status == fake_bool_ts
+
+            da_system_kws = SystemDA(
+                buses=buses,
+                generators=gens,
+                loads=fake_gen_ts,
+                branches=branches,
+                zones=zones,
+                generator_time_series=generator_time_series,
+                generator_status=da_gen_status,
+                increment=fake_offer_ts,
+                decrement=fake_offer_ts,
+                price_sensitive_demand=fake_offer_ts,
+                gens_per_bus=gens_per_bus,
+                incs_per_bus=incs_per_bus,
+                decs_per_bus=decs_per_bus,
+                psds_per_bus=psds_per_bus,
+                loads_per_bus=loads_per_bus,
+                lodf=lodf,
+                ptdf=ptdf,
+            )
+            @test da_system_kws isa SystemDA
+            @test da_system_kws.ptdf == ptdf
+
+            rt_system_kws = SystemRT(
+                gens_per_bus=gens_per_bus,
+                loads_per_bus=loads_per_bus,
+                zones=zones,
+                buses=buses,
+                generators=gens,
+                branches=branches,
+                lodf=lodf,
+                ptdf=ptdf,
+                generator_time_series=generator_time_series,
+                generator_status=rt_gen_status,
+                loads=fake_gen_ts
+            )
+            @test rt_system_kws isa SystemRT
+            @test rt_system_kws.lodf == lodf
+        end
+
         @testset "System accessor functions" begin
             @testset "Common accessors $T" for (system, T) in (
                 (da_system, SystemDA), (rt_system, SystemRT)

--- a/test/system.jl
+++ b/test/system.jl
@@ -142,7 +142,7 @@
                 number=1, regulation=10.0, operating_reserve=20.0, good_utility=5.0
             )
             @test zone_kws isa Zone
-            @test zone.regulation == 10.0
+            @test zone_kws.regulation == 10.0
 
             generator_kws = Generator(
                 unit_code=1,
@@ -170,6 +170,7 @@
                 rate_a=50.0,
                 rate_b=55.0,
                 is_monitored=true,
+                is_transformer=false,
                 break_points=(1.0, 2.0),
                 penalties=(3.0, 4.0),
                 resistance=1.0,

--- a/test/system.jl
+++ b/test/system.jl
@@ -25,7 +25,7 @@
             zone=1,
             startup_cost=0.0,
             shutdown_cost=1.0,
-            noload_cost=1.0,
+            no_load_cost=1.0,
             min_uptime=24.0,
             min_downtime=24.0,
             ramp_up=2.0,
@@ -57,14 +57,14 @@
         @test !branch1.is_transformer
 
         branch2 = Branch(
-            name="2",
-            to_bus="A",
-            from_bus="C",
-            rate_a=10.0,
-            rate_b=10.0,
-            is_monitored=true,
-            break_points=(100.0, 102.0),
-            penalties=(5.0, 6.0)
+            "2",
+            "A",
+            "C",
+            10.0,
+            10.0,
+            true,
+            (100.0, 102.0),
+            (5.0, 6.0)
         )
         @test branch2 isa Branch
         @test !branch2.is_transformer


### PR DESCRIPTION
This makes it easier to keep track of arguments when using these structs, as some of them have many arguments.