### PR TITLE
Make testing of accessors more precise

### DIFF
--- a/test/system.jl
+++ b/test/system.jl
@@ -121,7 +121,7 @@
         services_time_series() = KeyedArray(vcat(rand(length(ids) - 1, length(datetimes)), fill(missing, 1, length(datetimes))); ids, datetimes)
         offer_time_series() = KeyedArray(fill([(1.0, 100.0)], length(ids), length(datetimes)); ids, datetimes)
 
-        initial_generation = KeyedArray(rand(length(ids)); ids)
+        initial_generation = KeyedArray([rand(length(ids) - 2); fill(0.0, 2)]; ids)
         offer_curve = offer_time_series()
         regulation_min = time_series()
         regulation_max = time_series()
@@ -250,6 +250,7 @@
 
             @testset "SystemDA only accessors" begin
                 @test get_initial_commitment(da_system) isa KeyedArray{Bool, 1}
+                @test get_initial_commitment(da_system) == [trues(length(ids) - 2); falses(2)]
                 @test get_incs_per_bus(da_system) == incs_per_bus
                 @test get_decs_per_bus(da_system) == decs_per_bus
                 @test get_psds_per_bus(da_system) == psds_per_bus

--- a/test/system.jl
+++ b/test/system.jl
@@ -1,18 +1,4 @@
 @testset "system.jl" begin
-    datetimes = DateTime(2017, 12, 15):Hour(1):DateTime(2017, 12, 15, 23)
-    gen_ids = collect(111:1:120)
-    l = length(gen_ids)
-    fake_vec_ts = KeyedArray(rand(10); ids=gen_ids)
-    fake_gen_ts = KeyedArray(rand(10, 24); ids=gen_ids, datetimes=datetimes)
-    fake_offer_ts = KeyedArray(
-        repeat([[(1.0, 100.0)]], inner=(1, 24), outer=(10, 1));
-        ids=gen_ids, datetimes=datetimes
-    )
-    fake_bool_ts = KeyedArray(rand(Bool, 10, 24); ids=gen_ids, datetimes=datetimes)
-    fake_services_ts = KeyedArray(
-        vcat(rand(9, 24), fill(missing, 24)');
-        ids=gen_ids, datetimes=datetimes
-    )
 
     @testset "Zone" begin
         zone1 = Zone(number=1, regulation=1.0, operating_reserve=1.0, good_utility=1.0)
@@ -92,10 +78,11 @@
         zone_market = Zone(-9999, 3.0, 3.0, 3.0)
         zones = Dictionary([1, 2, -9999], [zone1, zone2, zone_market])
 
+        gen_ids = collect(111:1:120)
         gen_types = map(gen_ids) do id
             Generator(id, zone1.number, 0.0, 1.0, 1.0, 24.0, 24.0, 2.0, 2.0, :tech)
         end
-        gens = Dictionary(gen_ids, gen_types)
+        generators = Dictionary(gen_ids, gen_types)
 
         bus_names = ["A", "B", "C"]
         bus_types = map(bus_names) do name
@@ -128,55 +115,84 @@
         )
         ptdf = KeyedArray(rand(4, 3); row=branch_names, col=bus_names)
 
-        generator_time_series = GeneratorTimeSeries(
-            initial_generation=fake_vec_ts,
-            offer_curve=fake_offer_ts,
-            regulation_min=fake_gen_ts,
-            regulation_max=fake_gen_ts,
-            pmin=fake_gen_ts,
-            pmax=fake_gen_ts,
-            asm_regulation=fake_services_ts,
-            asm_spin=fake_services_ts,
-            asm_sup_on=fake_services_ts,
-            asm_sup_off=fake_services_ts
+        ids = gen_ids
+        datetimes = DateTime(2017, 12, 15):Hour(1):DateTime(2017, 12, 15, 23)
+        time_series(T=Float64) = KeyedArray(rand(T, length(ids), length(datetimes)); ids, datetimes)
+        services_time_series() = KeyedArray(vcat(rand(length(ids) - 1, length(datetimes)), fill(missing, 1, length(datetimes))); ids, datetimes)
+        offer_time_series() = KeyedArray(fill([(1.0, 100.0)], length(ids), length(datetimes)); ids, datetimes)
+
+        initial_generation = KeyedArray(rand(length(ids)); ids)
+        offer_curve = offer_time_series()
+        regulation_min = time_series()
+        regulation_max = time_series()
+        pmin = time_series()
+        pmax = time_series()
+        pmin = time_series()
+        pmax = time_series()
+        asm_regulation = services_time_series()
+        asm_spin = services_time_series()
+        asm_sup_on = services_time_series()
+        asm_sup_off = services_time_series()
+
+        generator_time_series = GeneratorTimeSeries(;
+            initial_generation,
+            offer_curve,
+            regulation_min,
+            regulation_max,
+            pmin,
+            pmax,
+            asm_regulation,
+            asm_spin,
+            asm_sup_on,
+            asm_sup_off,
         )
-        da_gen_status = GeneratorStatusDA(
-            hours_at_status=fake_vec_ts, availability=fake_bool_ts, must_run=fake_bool_ts
-        )
-        da_system = SystemDA(
-            gens_per_bus=gens_per_bus,
-            incs_per_bus=incs_per_bus,
-            decs_per_bus=decs_per_bus,
-            psds_per_bus=psds_per_bus,
-            loads_per_bus=loads_per_bus,
-            zones=zones,
-            buses=buses,
-            generators=gens,
-            branches=branches,
-            lodf=lodf,
-            ptdf=ptdf,
-            generator_time_series=generator_time_series,
-            generator_status=da_gen_status,
-            loads=fake_gen_ts,
-            increment=fake_offer_ts,
-            decrement=fake_offer_ts,
-            price_sensitive_demand=fake_offer_ts
+
+        hours_at_status = KeyedArray(rand(length(ids)); ids)
+        availability = time_series(Bool)
+        must_run = time_series(Bool)
+        da_generator_status = GeneratorStatusDA(; hours_at_status, availability, must_run)
+
+        loads = time_series()
+        increment = offer_time_series()
+        decrement = offer_time_series()
+        price_sensitive_demand = offer_time_series()
+        da_system = SystemDA(;
+            gens_per_bus,
+            incs_per_bus,
+            decs_per_bus,
+            psds_per_bus,
+            loads_per_bus,
+            zones,
+            buses,
+            generators,
+            branches,
+            lodf,
+            ptdf,
+            generator_time_series,
+            generator_status=da_generator_status,
+            loads,
+            increment,
+            decrement,
+            price_sensitive_demand,
         )
         @test da_system isa SystemDA
 
-        rt_gen_status = GeneratorStatusRT(fake_bool_ts, fake_bool_ts)
-        rt_system = SystemRT(
-            gens_per_bus=gens_per_bus,
-            loads_per_bus=loads_per_bus,
-            zones=zones,
-            buses=buses,
-            generators=gens,
-            branches=branches,
-            lodf=lodf,
-            ptdf=ptdf,
-            generator_time_series=generator_time_series,
-            generator_status=rt_gen_status,
-            loads=fake_gen_ts
+        status = time_series(Bool)
+        status_regulation = time_series(Bool)
+        rt_generator_status = GeneratorStatusRT(; status, status_regulation)
+
+        rt_system = SystemRT(;
+            gens_per_bus,
+            loads_per_bus,
+            zones,
+            buses,
+            generators,
+            branches,
+            lodf,
+            ptdf,
+            generator_time_series,
+            generator_status=rt_generator_status,
+            loads,
         )
         @test rt_system isa SystemRT
 
@@ -190,7 +206,7 @@
                 @test get_operating_reserve_requirements(system) == Dictionary([1, 2, -9999], [1.0, 2.0, 3.0])
                 @test get_good_utility_requirements(system) == Dictionary([1, 2, -9999], [1.0, 4.0, 3.0])
                 @test get_buses(system) == buses
-                @test get_generators(system) == gens
+                @test get_generators(system) == generators
                 @test get_branches(system) == branches
                 @test get_lines(system) == Dictionary(
                     ["1", "2", "3"], [branches["1"], branches["2"], branches["3"]]
@@ -203,18 +219,18 @@
                 @test get_ptdf(system) == ptdf
                 @test get_lodf(system) == lodf
 
-                @test get_initial_generation(system) == fake_vec_ts
-                @test get_load(system) == fake_gen_ts
-                @test get_offer_curve(system) == fake_offer_ts
-                @test get_pmin(system) == fake_gen_ts
-                @test get_pmax(system) == fake_gen_ts
-                @test get_regmin(system) == fake_gen_ts
-                @test get_regmax(system) == fake_gen_ts
+                @test get_initial_generation(system) == initial_generation
+                @test get_load(system) == loads
+                @test get_offer_curve(system) == offer_curve
+                @test get_pmin(system) == pmin
+                @test get_pmax(system) == pmax
+                @test get_regmin(system) == regulation_min
+                @test get_regmax(system) == regulation_max
 
-                @test skipmissing(get_regulation(system)) == skipmissing(fake_services_ts)
-                @test skipmissing(get_spinning(system)) == skipmissing(fake_services_ts)
-                @test skipmissing(get_supplemental_on(system)) == skipmissing(fake_services_ts)
-                @test skipmissing(get_supplemental_off(system)) == skipmissing(fake_services_ts)
+                @test skipmissing(get_regulation(system)) == skipmissing(asm_regulation)
+                @test skipmissing(get_spinning(system)) == skipmissing(asm_spin)
+                @test skipmissing(get_supplemental_on(system)) == skipmissing(asm_sup_on)
+                @test skipmissing(get_supplemental_off(system)) == skipmissing(asm_sup_off)
 
                 gens_by_zone = gens_per_zone(da_system)
                 @test issetequal(keys(gens_by_zone), [1, FullNetworkSystems.MARKET_WIDE_ZONE])
@@ -238,17 +254,17 @@
                 @test get_decs_per_bus(da_system) == decs_per_bus
                 @test get_psds_per_bus(da_system) == psds_per_bus
 
-                @test get_bids(da_system, :increment) == fake_offer_ts
-                @test get_bids(da_system, :decrement) == fake_offer_ts
-                @test get_bids(da_system, :price_sensitive_demand) == fake_offer_ts
+                @test get_bids(da_system, :increment) == increment
+                @test get_bids(da_system, :decrement) == decrement
+                @test get_bids(da_system, :price_sensitive_demand) == price_sensitive_demand
 
-                @test get_availability(da_system) == fake_bool_ts
-                @test get_must_run(da_system) == fake_bool_ts
+                @test get_availability(da_system) == availability
+                @test get_must_run(da_system) == must_run
             end
 
             @testset "SystemRT only accessors" begin
-                @test get_commitment(rt_system) == fake_bool_ts
-                @test get_regulation_commitment(rt_system) == fake_bool_ts
+                @test get_commitment(rt_system) == status
+                @test get_regulation_commitment(rt_system) == status_regulation
             end
         end
     end


### PR DESCRIPTION
- Before this accessor functions could have the wrong
  logic (e.g. access the wrong property) but accidentally
  pass tests because multiple properties had exactly
  the same values (or because values weren't tested)