### PR TITLE
Fix `branches_by_breakpoints` return type and test all paths

### DIFF
--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -127,17 +127,17 @@ function gens_per_zone(system::System)
 end
 
 """
-    branches_by_breakpoints(system::System)
+    branches_by_breakpoints(system::System) -> NTuple{3, Vector{$BranchName}}
 
 Returns three vectors containing of the names of branches which have 0, 1, and 2 breakpoints.
 """
 function branches_by_breakpoints(system::System)
-    zero_bp, one_bp, two_bp = String[], String[], String[]
+    zero_bp, one_bp, two_bp = BranchName[], BranchName[], BranchName[]
     for branch in system.branches
         if branch.is_monitored
-            if all(branch.break_points .== 0.0)
+            if all(iszero, branch.break_points)
                 push!(zero_bp, branch.name)
-            elseif last(branch.break_points) == 0.0
+            elseif iszero(last(branch.break_points))
                 push!(one_bp, branch.name)
             else
                 push!(two_bp, branch.name)

--- a/test/system.jl
+++ b/test/system.jl
@@ -94,11 +94,10 @@
         branches = Dictionary(
             branch_names,
             [
-                Branch("1", "A", "B", 10.0, 10.0, true, (100.0, 102.0), (5.0, 6.0), 1.0, 1.0),
-                Branch("2", "B", "C", 10.0, 10.0, false, (100.0, 0.0), (5.0, 0.0), 1.0, 1.0),
-                Branch("3", "C", "A", 10.0, 10.0, true, (0.0, 0.0), (0.0, 0.0), 1.0, 1.0),
-                Branch(
-                    "4", "A", "C", 10.0, 10.0, true, (100.0, 102.0), (5.0, 6.0), 1.0, 1.0, 0.5, 30.0
+                Branch("1", "A", "B", 10.0, 10.0, true,  (100.0, 102.0), (5.0, 6.0), 1.0, 1.0),
+                Branch("2", "B", "C", 10.0, 10.0, false, (100.0,   0.0), (5.0, 0.0), 1.0, 1.0),
+                Branch("3", "C", "A", 10.0, 10.0, true,  (0.0,     0.0), (0.0, 0.0), 1.0, 1.0),
+                Branch("4", "A", "C", 10.0, 10.0, true,  (100.0, 102.0), (5.0, 6.0), 1.0, 1.0, 0.5, 30.0,
                 )
             ]
         )
@@ -243,6 +242,22 @@
                 @test one_bp == [] # unmonitored
                 @test two_bp == ["1", "4"]
                 @test eltype(zero_bp) == eltype(one_bp) == eltype(two_bp) == FullNetworkSystems.BranchName
+
+                # Also test on a system with a 1-breakpoint branch
+                da_system.branches = Dictionary(
+                    branch_names,
+                    [
+                        Branch("1", "A", "B", 10.0, 10.0, true, (100.0, 102.0), (5.0, 6.0), 1.0, 1.0),
+                        Branch("2", "B", "C", 10.0, 10.0, true, (100.0,   0.0), (5.0, 0.0), 1.0, 1.0),
+                        Branch("3", "C", "A", 10.0, 10.0, true, (0.0,     0.0), (5.0, 6.0), 1.0, 1.0),
+                        Branch("4", "A", "C", 10.0, 10.0, true, (100.0, 102.0), (5.0, 6.0), 1.0, 1.0),
+                    ]
+                )
+                zero_bp, one_bp, two_bp = branches_by_breakpoints(da_system)
+                @test zero_bp == ["3"]
+                @test one_bp == ["2"]
+                @test two_bp == ["1", "4"]
+                da_system.branches = branches  # reset
 
                 # Check that we can remove the PTDF
                 system.ptdf = missing

--- a/test/system.jl
+++ b/test/system.jl
@@ -231,7 +231,7 @@
                 @test skipmissing(get_supplemental_on(system)) == skipmissing(asm_sup_on)
                 @test skipmissing(get_supplemental_off(system)) == skipmissing(asm_sup_off)
 
-                gens_by_zone = gens_per_zone(da_system)
+                gens_by_zone = gens_per_zone(system)
                 @test issetequal(keys(gens_by_zone), [1, FullNetworkSystems.MARKET_WIDE_ZONE])
                 for (_, v) in gens_by_zone
                     @test v == gen_ids

--- a/test/system.jl
+++ b/test/system.jl
@@ -238,10 +238,11 @@
                     @test v == gen_ids
                 end
 
-                zero_bp, one_bp, two_bp = branches_by_breakpoints(da_system)
+                zero_bp, one_bp, two_bp = branches_by_breakpoints(system)
                 @test zero_bp == ["3"]
-                @test one_bp == String[] #unmonitored
+                @test one_bp == [] # unmonitored
                 @test two_bp == ["1", "4"]
+                @test eltype(zero_bp) == eltype(one_bp) == eltype(two_bp) == FullNetworkSystems.BranchName
 
                 # Check that we can remove the PTDF
                 system.ptdf = missing


### PR DESCRIPTION
- Before this accidentally converted branch names to `String` rather than leaving them as whatever `AbstractString` type they already were
- Also adds a test for the case where a monitored branch has a single break point, to increase test coverage
- This is a bug-fix but package version not bumped as already bumped to v1.4.0 on `main` without a release (due to needing to devide about #23)