### PR TITLE
Rename accessors and fieldnames to give clearer and more consistent API

### DIFF
--- a/src/FullNetworkSystems.jl
+++ b/src/FullNetworkSystems.jl
@@ -13,10 +13,10 @@ export GeneratorTimeSeries, GeneratorStatus, GeneratorStatusDA, GeneratorStatusR
 export gens_per_zone, branches_by_breakpoints, get_datetimes
 export get_zones, get_buses, get_generators, get_branches, get_lines, get_transformers
 export get_regulation_requirements, get_operating_reserve_requirements, get_good_utility_requirements
-export get_gens_per_bus, get_loads_per_bus, get_incs_per_bus, get_decs_per_bus, get_psds_per_bus
+export get_gens_per_bus, get_loads_per_bus, get_incs_per_bus, get_decs_per_bus, get_psls_per_bus
 export get_ptdf, get_lodfs
 export get_initial_commitment, get_initial_downtime, get_initial_uptime
-export get_increments, get_decrements, get_price_sensitive_demands
+export get_increments, get_decrements, get_price_sensitive_loads
 export get_availability, get_must_run
 export get_initial_generation, get_loads, get_offer_curve
 export get_pmin, get_pmax, get_regulation_min, get_regulation_max

--- a/src/FullNetworkSystems.jl
+++ b/src/FullNetworkSystems.jl
@@ -19,7 +19,7 @@ export get_initial_commitment, get_initial_downtime, get_initial_uptime
 export get_bids, get_availability, get_must_run
 export get_initial_generation, get_loads, get_offer_curve
 export get_pmin, get_pmax, get_regulation_min, get_regulation_max
-export get_regulation, get_spinning, get_supplemental_on, get_supplemental_off
+export get_regulation_offers, get_spinning_offers, get_on_supplemental_offers, get_off_supplemental_offers
 export get_commitment, get_regulation_commitment
 
 include("system.jl")

--- a/src/FullNetworkSystems.jl
+++ b/src/FullNetworkSystems.jl
@@ -18,7 +18,7 @@ export get_ptdf, get_lodfs
 export get_initial_commitment, get_initial_downtime, get_initial_uptime
 export get_bids, get_availability, get_must_run
 export get_initial_generation, get_load, get_offer_curve
-export get_pmin, get_pmax, get_regmin, get_regmax
+export get_pmin, get_pmax, get_regulation_min, get_regulation_max
 export get_regulation, get_spinning, get_supplemental_on, get_supplemental_off
 export get_commitment, get_regulation_commitment
 

--- a/src/FullNetworkSystems.jl
+++ b/src/FullNetworkSystems.jl
@@ -16,7 +16,8 @@ export get_regulation_requirements, get_operating_reserve_requirements, get_good
 export get_gens_per_bus, get_loads_per_bus, get_incs_per_bus, get_decs_per_bus, get_psds_per_bus
 export get_ptdf, get_lodfs
 export get_initial_commitment, get_initial_downtime, get_initial_uptime
-export get_bids, get_availability, get_must_run
+export get_increments, get_decrements, get_price_sensitive_demands
+export get_availability, get_must_run
 export get_initial_generation, get_loads, get_offer_curve
 export get_pmin, get_pmax, get_regulation_min, get_regulation_max
 export get_regulation_offers, get_spinning_offers, get_on_supplemental_offers, get_off_supplemental_offers

--- a/src/FullNetworkSystems.jl
+++ b/src/FullNetworkSystems.jl
@@ -17,7 +17,7 @@ export get_gens_per_bus, get_loads_per_bus, get_incs_per_bus, get_decs_per_bus, 
 export get_ptdf, get_lodfs
 export get_initial_commitment, get_initial_downtime, get_initial_uptime
 export get_bids, get_availability, get_must_run
-export get_initial_generation, get_load, get_offer_curve
+export get_initial_generation, get_loads, get_offer_curve
 export get_pmin, get_pmax, get_regulation_min, get_regulation_max
 export get_regulation, get_spinning, get_supplemental_on, get_supplemental_off
 export get_commitment, get_regulation_commitment

--- a/src/FullNetworkSystems.jl
+++ b/src/FullNetworkSystems.jl
@@ -14,7 +14,7 @@ export gens_per_zone, branches_by_breakpoints, get_datetimes
 export get_zones, get_buses, get_generators, get_branches, get_lines, get_transformers
 export get_regulation_requirements, get_operating_reserve_requirements, get_good_utility_requirements
 export get_gens_per_bus, get_loads_per_bus, get_incs_per_bus, get_decs_per_bus, get_psds_per_bus
-export get_ptdf, get_lodf
+export get_ptdf, get_lodfs
 export get_initial_commitment, get_initial_downtime, get_initial_uptime
 export get_bids, get_availability, get_must_run
 export get_initial_generation, get_load, get_offer_curve
@@ -24,5 +24,6 @@ export get_commitment, get_regulation_commitment
 
 include("system.jl")
 include("accessors.jl")
+include("deprecated.jl")
 
 end

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -63,9 +63,9 @@ get_pmin(system::System) = system.generator_time_series.pmin
 "Returns time series data of maximum generator output (pu)"
 get_pmax(system::System) = system.generator_time_series.pmax
 "Returns time series data of minimum generator output in the ancillary services market (pu)"
-get_regmin(system::System) = system.generator_time_series.regulation_min
+get_regulation_min(system::System) = system.generator_time_series.regulation_min
 "Returns time series data of maximum generator output in the ancillary services market (pu)"
-get_regmax(system::System) = system.generator_time_series.regulation_max
+get_regulation_max(system::System) = system.generator_time_series.regulation_max
 
 "Returns time series data of offer prices for ancillary servives regulation (\$ /pu)"
 get_regulation(system::System) = system.generator_time_series.asm_regulation

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -54,8 +54,8 @@ get_lodfs(system::System) = system.lodfs
 
 "Returns the generation of the generator at the start of the time period (pu)"
 get_initial_generation(system::System) = system.generator_time_series.initial_generation
-"Returns time series data of the load in the system"
-get_load(system::System) = system.loads
+"Returns time series data of the loads in the system"
+get_loads(system::System) = system.loads
 "Returns time series data of the generator offer curves"
 get_offer_curve(system::System) = system.generator_time_series.offer_curve
 "Returns time series data of minimum generator output (pu)"

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -54,7 +54,7 @@ get_lodfs(system::System) = system.lodfs
 
 "Returns the generation of the generator at the start of the time period (pu)"
 get_initial_generation(system::System) = system.generator_time_series.initial_generation
-"Returns time series data of the loads in the system"
+"Returns time series data of the fixed loads in the system"
 get_loads(system::System) = system.loads
 "Returns time series data of the generator offer curves"
 get_offer_curve(system::System) = system.generator_time_series.offer_curve

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -49,8 +49,8 @@ get_loads_per_bus(system::System) = system.loads_per_bus
 
 "Returns the power transfer distribution factor of the system."
 get_ptdf(system::System) = system.ptdf
-"Returns the line outage distribution factor matrix of the system for a set of contingencies."
-get_lodf(system::System) = system.lodf
+"Returns a `Dictionary` of the line outage distribution factor matrices for the `System` indexed by contingencies."
+get_lodfs(system::System) = system.lodfs
 
 "Returns the generation of the generator at the start of the time period (pu)"
 get_initial_generation(system::System) = system.generator_time_series.initial_generation

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -113,10 +113,10 @@ get_availability(system::SystemDA) = system.generator_status.availability
 "Returns time series data of flags indicating if the generator must be committed in each hour"
 get_must_run(system::SystemDA) = system.generator_status.must_run
 
-"Returns time series data of generator status in each hour"
-get_commitment(system::SystemRT) = system.generator_status.status
-"Returns time series data of generator regulation status in each hour"
-get_regulation_commitment(system::SystemRT) = system.generator_status.status_regulation
+"Returns time series data of generator commitment status in each hour"
+get_commitment(system::SystemRT) = system.generator_status.commitment
+"Returns time series data of generator regulation commitment status in each hour"
+get_regulation_commitment(system::SystemRT) = system.generator_status.regulation_commitment
 
 """
     gens_per_zone(system::System)

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -97,15 +97,15 @@ end
 get_incs_per_bus(system::SystemDA) = system.incs_per_bus
 "Returns a `Dictionary` of decrement bids at each bus."
 get_decs_per_bus(system::SystemDA) = system.decs_per_bus
-"Returns a `Dictionary` of price sensitive demand bids at each bus."
-get_psds_per_bus(system::SystemDA) = system.psds_per_bus
+"Returns a `Dictionary` of price sensitive load bids at each bus."
+get_psls_per_bus(system::SystemDA) = system.psls_per_bus
 
 "Returns time series data of increment bids."
 get_increments(system::SystemDA) = system.increments
 "Returns time series data of decrement bids."
 get_decrements(system::SystemDA) = system.decrements
-"Returns time series data of price sensitive demand bids."
-get_price_sensitive_demands(system::SystemDA) = system.price_sensitive_demands
+"Returns time series data of price sensitive load bids."
+get_price_sensitive_loads(system::SystemDA) = system.price_sensitive_loads
 
 "Returns time series data of flags indicating if the generator is available to be committed in each hour"
 get_availability(system::SystemDA) = system.generator_status.availability

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -67,14 +67,14 @@ get_regulation_min(system::System) = system.generator_time_series.regulation_min
 "Returns time series data of maximum generator output in the ancillary services market (pu)"
 get_regulation_max(system::System) = system.generator_time_series.regulation_max
 
-"Returns time series data of offer prices for ancillary servives regulation (\$ /pu)"
-get_regulation(system::System) = system.generator_time_series.asm_regulation
-"Returns time series data of offer prices for ancillary servives spinning (\$ /pu)"
-get_spinning(system::System) = system.generator_time_series.asm_spin
-"Returns time series data of offer prices for ancillary servives supplemental on (\$ /pu)"
-get_supplemental_on(system::System) = system.generator_time_series.asm_sup_on
-"Returns time series data of offer prices for ancillary servives supplemental off (\$ /pu)"
-get_supplemental_off(system::System) = system.generator_time_series.asm_sup_off
+"Returns time series data of offer prices for ancillary servives regulation reserves (\$ /pu)"
+get_regulation_offers(system::System) = system.generator_time_series.regulation_offers
+"Returns time series data of offer prices for ancillary servives spinning reserves (\$ /pu)"
+get_spinning_offers(system::System) = system.generator_time_series.spinning_offers
+"Returns time series data of offer prices for ancillary servives online supplemental reserves (\$ /pu)"
+get_on_supplemental_offers(system::System) = system.generator_time_series.on_supplemental_offers
+"Returns time series data of offer prices for ancillary servives offline supplemental reserves (\$ /pu)"
+get_off_supplemental_offers(system::System) = system.generator_time_series.off_supplemental_offers
 
 "Returns a flag indicating whether each generator was on at the start of the day."
 function get_initial_commitment(system::SystemDA)

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -100,13 +100,12 @@ get_decs_per_bus(system::SystemDA) = system.decs_per_bus
 "Returns a `Dictionary` of price sensitive demand bids at each bus."
 get_psds_per_bus(system::SystemDA) = system.psds_per_bus
 
-"""
-Returns time series data of bids for the bid type indicated.  Bid type must be one of
-`:increment`, `:decrement` or `:price_sensitive_demand`.
-"""
-function get_bids(system::SystemDA, type_of_bid::Symbol)
-    return getproperty(system, type_of_bid)
-end
+"Returns time series data of increment bids."
+get_increments(system::SystemDA) = system.increments
+"Returns time series data of decrement bids."
+get_decrements(system::SystemDA) = system.decrements
+"Returns time series data of price sensitive demand bids."
+get_price_sensitive_demands(system::SystemDA) = system.price_sensitive_demands
 
 "Returns time series data of flags indicating if the generator is available to be committed in each hour"
 get_availability(system::SystemDA) = system.generator_status.availability

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,3 +1,6 @@
 # v1 deprecations, to be removed in v2
 
 @deprecate get_lodf(system::System) get_lodfs(system)
+
+@deprecate get_regmin(system::System) get_regulation_min(system)
+@deprecate get_regmax(system::System) get_regulation_max(system)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -6,3 +6,8 @@
 @deprecate get_regmax(system::System) get_regulation_max(system)
 
 @deprecate get_load(system::System) get_loads(system)
+
+@deprecate get_regulation(system::System) get_regulation_offers(system)
+@deprecate get_spinning(system::System) get_spinning_offers(system)
+@deprecate get_supplemental_on(system::System) get_on_supplemental_offers(system)
+@deprecate get_supplemental_off(system::System) get_off_supplemental_offers(system)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -11,3 +11,20 @@
 @deprecate get_spinning(system::System) get_spinning_offers(system)
 @deprecate get_supplemental_on(system::System) get_on_supplemental_offers(system)
 @deprecate get_supplemental_off(system::System) get_off_supplemental_offers(system)
+
+export get_bids
+function get_bids(system::SystemDA, type_of_bid::Symbol)
+    if type_of_bid === :increment
+        Base.depwarn("`get_bids(system, :increment)` is deprecated, use `get_increments(system)` instead.", :get_bids)
+        return get_increments(system)
+    elseif type_of_bid === :decrement
+        Base.depwarn("`get_bids(system, :decrement)` is deprecated, use `get_decrements(system)` instead.", :get_bids)
+        return get_decrements(system)
+    elseif type_of_bid === :price_sensitive_demand
+        Base.depwarn("`get_bids(system, :price_sensitive_demand)` is deprecated, use `get_price_sensitive_demands(system)` instead.", :get_bids)
+        return get_price_sensitive_demands(system)
+    else
+        Base.depwarn("`get_bids` is deprecated, use `get_increments` or `get_decrements` or `get_price_sensitive_demands`.", :get_bids)
+        return getproperty(system, type_of_bid)
+    end
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -12,6 +12,8 @@
 @deprecate get_supplemental_on(system::System) get_on_supplemental_offers(system)
 @deprecate get_supplemental_off(system::System) get_off_supplemental_offers(system)
 
+@deprecate get_psds_per_bus(system::System) get_psls_per_bus(system)
+
 export get_bids
 function get_bids(system::SystemDA, type_of_bid::Symbol)
     if type_of_bid === :increment
@@ -21,10 +23,10 @@ function get_bids(system::SystemDA, type_of_bid::Symbol)
         Base.depwarn("`get_bids(system, :decrement)` is deprecated, use `get_decrements(system)` instead.", :get_bids)
         return get_decrements(system)
     elseif type_of_bid === :price_sensitive_demand
-        Base.depwarn("`get_bids(system, :price_sensitive_demand)` is deprecated, use `get_price_sensitive_demands(system)` instead.", :get_bids)
-        return get_price_sensitive_demands(system)
+        Base.depwarn("`get_bids(system, :price_sensitive_demand)` is deprecated, use `get_price_sensitive_loads(system)` instead.", :get_bids)
+        return get_price_sensitive_loads(system)
     else
-        Base.depwarn("`get_bids` is deprecated, use `get_increments` or `get_decrements` or `get_price_sensitive_demands`.", :get_bids)
+        Base.depwarn("`get_bids` is deprecated, use `get_increments` or `get_decrements` or `get_price_sensitive_loads`.", :get_bids)
         return getproperty(system, type_of_bid)
     end
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -4,3 +4,5 @@
 
 @deprecate get_regmin(system::System) get_regulation_min(system)
 @deprecate get_regmax(system::System) get_regulation_max(system)
+
+@deprecate get_load(system::System) get_loads(system)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,3 @@
+# v1 deprecations, to be removed in v2
+
+@deprecate get_lodf(system::System) get_lodfs(system)

--- a/src/system.jl
+++ b/src/system.jl
@@ -296,7 +296,7 @@ Fields:
 $TYPEDFIELDS
 """
 Base.@kwdef struct GeneratorStatusDA <: GeneratorStatus
-    "Hours each generator has been at its current status at the start of the day"
+    "Hours each generator has been at its current commitment status at the start of the day"
     hours_at_status::KeyedArray{Float64, 1}
     "Flag indicating if the generator is available to be committed in each hour"
     availability::KeyedArray{Bool, 2}
@@ -314,9 +314,9 @@ $TYPEDFIELDS
 """
 Base.@kwdef struct GeneratorStatusRT <: GeneratorStatus
     "Generator commitment status indicated by a `Bool`"
-    status::KeyedArray{Bool, 2}
+    commitment::KeyedArray{Bool, 2}
     "Generator regulation commitment status indicated by a `Bool`"
-    status_regulation::KeyedArray{Bool, 2}
+    regulation_commitment::KeyedArray{Bool, 2}
 end
 
 """

--- a/src/system.jl
+++ b/src/system.jl
@@ -348,10 +348,10 @@ Base.@kwdef mutable struct SystemDA <: System
     "`Dictionary` where the keys are bus names and the values are decrement bid ids at that bus"
     decs_per_bus::Dictionary{BusName, Vector{BidName}}
     """
-    `Dictionary` where the keys are bus names and the values are price sensitive demand bid
+    `Dictionary` where the keys are bus names and the values are price sensitive load bid
     ids at that bus
     """
-    psds_per_bus::Dictionary{BusName, Vector{BidName}}
+    psls_per_bus::Dictionary{BusName, Vector{BidName}}
     "`Dictionary` where the keys are bus names and the values are load ids at that bus"
     loads_per_bus::Dictionary{BusName, Vector{BidName}}
 
@@ -390,8 +390,8 @@ Base.@kwdef mutable struct SystemDA <: System
     increments::KeyedArray{Vector{Tuple{Float64, Float64}}, 2}
     "Decrement bids time series data. `KeyedArray` where the axis keys are `bid ids x datetimes`"
     decrements::KeyedArray{Vector{Tuple{Float64, Float64}}, 2}
-    "Price sensitive demand bids time series data. `KeyedArray` where the axis keys are `bid ids x datetimes`"
-    price_sensitive_demands::KeyedArray{Vector{Tuple{Float64, Float64}}, 2}
+    "Price sensitive load bids time series data. `KeyedArray` where the axis keys are `bid ids x datetimes`"
+    price_sensitive_loads::KeyedArray{Vector{Tuple{Float64, Float64}}, 2}
 end
 
 """

--- a/src/system.jl
+++ b/src/system.jl
@@ -259,25 +259,25 @@ Base.@kwdef struct GeneratorTimeSeries
     "Generator maximum output (pu)"
     pmax::KeyedArray{Float64, 2}
     """
-    Ancillary services regulation offer prices (\$ /pu). Generators not providing the service
-    will have `missing` offer data
+    Ancillary services regulation reserve offer prices (\$ /pu).
+    Generators not providing the service will have `missing` offer data.
     """
-    asm_regulation::KeyedArray{Union{Missing, Float64}, 2}
+    regulation_offers::KeyedArray{Union{Missing, Float64}, 2}
     """
-    Ancillary services spinning offer prices (\$ /pu). Generators not providing the service
-    will have `missing` offer data
+    Ancillary services spinning reserve offer prices (\$ /pu).
+    Generators not providing the service will have `missing` offer data.
     """
-    asm_spin::KeyedArray{Union{Missing, Float64}, 2}
+    spinning_offers::KeyedArray{Union{Missing, Float64}, 2}
     """
-    Ancillary services supplemental on offer prices (\$ /pu). Generators not providing the service
-    will have `missing` offer data
+    Ancillary services online supplemental reserve offer prices (\$ /pu).
+    Generators not providing the service will have `missing` offer data.
     """
-    asm_sup_on::KeyedArray{Union{Missing, Float64}, 2}
+    on_supplemental_offers::KeyedArray{Union{Missing, Float64}, 2}
     """
-    Ancillary services supplemental off offer prices (\$ /pu). Generators not providing the service
-    will have `missing` offer data
+    Ancillary services offline supplemental reserve offer prices (\$ /pu).
+    Generators not providing the service will have `missing` offer data.
     """
-    asm_sup_off::KeyedArray{Union{Missing, Float64}, 2}
+    off_supplemental_offers::KeyedArray{Union{Missing, Float64}, 2}
 end
 
 """

--- a/src/system.jl
+++ b/src/system.jl
@@ -387,11 +387,11 @@ Base.@kwdef mutable struct SystemDA <: System
 
     # Virtuals/PSD time series
     "Increment bids time series data. `KeyedArray` where the axis keys are `bid ids x datetimes`"
-    increment::KeyedArray{Vector{Tuple{Float64, Float64}}, 2}
+    increments::KeyedArray{Vector{Tuple{Float64, Float64}}, 2}
     "Decrement bids time series data. `KeyedArray` where the axis keys are `bid ids x datetimes`"
-    decrement::KeyedArray{Vector{Tuple{Float64, Float64}}, 2}
+    decrements::KeyedArray{Vector{Tuple{Float64, Float64}}, 2}
     "Price sensitive demand bids time series data. `KeyedArray` where the axis keys are `bid ids x datetimes`"
-    price_sensitive_demand::KeyedArray{Vector{Tuple{Float64, Float64}}, 2}
+    price_sensitive_demands::KeyedArray{Vector{Tuple{Float64, Float64}}, 2}
 end
 
 """

--- a/src/system.jl
+++ b/src/system.jl
@@ -368,7 +368,7 @@ Base.@kwdef mutable struct SystemDA <: System
     by the keys of the `Dictionary`. Each entry is a `KeyedArray` with axis keys
     `branch names x branch on outage`
     """
-    lodf::Dictionary{String, KeyedArray{Float64, 2}}
+    lodfs::Dictionary{String, KeyedArray{Float64, 2}}
     """
     Power transfer distribution factor of the system.  `KeyedArray` where the axis keys are
     `branch names x bus names`
@@ -421,7 +421,7 @@ Base.@kwdef mutable struct SystemRT <: System
     by the keys of the `Dictionary`. Each entry is a `KeyedArray` with axis keys
     `branch names x branch on outage`
     """
-    lodf::Dictionary{String, KeyedArray{Float64, 2}}
+    lodfs::Dictionary{String, KeyedArray{Float64, 2}}
     """
     Power transfer distribution factor of the system.  `KeyedArray` where the axis keys are
     `branch names x bus names`

--- a/test/system.jl
+++ b/test/system.jl
@@ -219,7 +219,7 @@
                 @test get_lodfs(system) == lodfs
 
                 @test get_initial_generation(system) == initial_generation
-                @test get_load(system) == loads
+                @test get_loads(system) == loads
                 @test get_offer_curve(system) == offer_curve
                 @test get_pmin(system) == pmin
                 @test get_pmax(system) == pmax
@@ -268,6 +268,8 @@
 
                     @test (@test_deprecated get_regmin(system)) == regulation_min
                     @test (@test_deprecated get_regmax(system)) == regulation_max
+
+                    @test (@test_deprecated get_load(system)) == loads
                 end
             end
 

--- a/test/system.jl
+++ b/test/system.jl
@@ -108,7 +108,7 @@
         psds_per_bus = Dictionary(bus_names, string.(rand('A':'Z', 3)) for _ in bus_names)
         loads_per_bus = Dictionary(bus_names, string.(rand('A':'Z', 3)) for _ in bus_names)
 
-        lodf = Dictionary(
+        lodfs = Dictionary(
             ["CONTIN_1"],
             [KeyedArray(rand(4, 1); branches=branch_names, branch=[first(branch_names)])]
         )
@@ -165,7 +165,7 @@
             buses,
             generators,
             branches,
-            lodf,
+            lodfs,
             ptdf,
             generator_time_series,
             generator_status=da_generator_status,
@@ -187,7 +187,7 @@
             buses,
             generators,
             branches,
-            lodf,
+            lodfs,
             ptdf,
             generator_time_series,
             generator_status=rt_generator_status,
@@ -216,7 +216,7 @@
                 @test get_loads_per_bus(system) == loads_per_bus
 
                 @test get_ptdf(system) == ptdf
-                @test get_lodf(system) == lodf
+                @test get_lodfs(system) == lodfs
 
                 @test get_initial_generation(system) == initial_generation
                 @test get_load(system) == loads
@@ -262,6 +262,10 @@
                 # Check that we can remove the PTDF
                 system.ptdf = missing
                 @test system.ptdf === missing
+
+                @testset "deprecated" begin
+                    @test (@test_deprecated get_lodf(system)) == lodfs
+                end
             end
 
             @testset "SystemDA only accessors" begin

--- a/test/system.jl
+++ b/test/system.jl
@@ -105,7 +105,7 @@
         gens_per_bus = Dictionary(bus_names, rand(gen_ids, 3) for _ in bus_names)
         incs_per_bus = Dictionary(bus_names, string.(rand('A':'Z', 3)) for _ in bus_names)
         decs_per_bus = Dictionary(bus_names, string.(rand('A':'Z', 3)) for _ in bus_names)
-        psds_per_bus = Dictionary(bus_names, string.(rand('A':'Z', 3)) for _ in bus_names)
+        psls_per_bus = Dictionary(bus_names, string.(rand('A':'Z', 3)) for _ in bus_names)
         loads_per_bus = Dictionary(bus_names, string.(rand('A':'Z', 3)) for _ in bus_names)
 
         lodfs = Dictionary(
@@ -154,12 +154,12 @@
         loads = time_series()
         increments = offer_time_series()
         decrements = offer_time_series()
-        price_sensitive_demands = offer_time_series()
+        price_sensitive_loads = offer_time_series()
         da_system = SystemDA(;
             gens_per_bus,
             incs_per_bus,
             decs_per_bus,
-            psds_per_bus,
+            psls_per_bus,
             loads_per_bus,
             zones,
             buses,
@@ -172,7 +172,7 @@
             loads,
             increments,
             decrements,
-            price_sensitive_demands,
+            price_sensitive_loads,
         )
         @test da_system isa SystemDA
 
@@ -286,11 +286,11 @@
 
                 @test get_incs_per_bus(da_system) == incs_per_bus
                 @test get_decs_per_bus(da_system) == decs_per_bus
-                @test get_psds_per_bus(da_system) == psds_per_bus
+                @test get_psls_per_bus(da_system) == psls_per_bus
 
                 @test get_increments(da_system) == increments
                 @test get_decrements(da_system) == decrements
-                @test get_price_sensitive_demands(da_system) == price_sensitive_demands
+                @test get_price_sensitive_loads(da_system) == price_sensitive_loads
 
                 @test get_availability(da_system) == availability
                 @test get_must_run(da_system) == must_run
@@ -298,7 +298,8 @@
                 @testset "deprecated" begin
                     @test (@test_deprecated get_bids(da_system, :increment)) == increments
                     @test (@test_deprecated get_bids(da_system, :decrement)) == decrements
-                    @test (@test_deprecated get_bids(da_system, :price_sensitive_demand)) == price_sensitive_demands
+                    @test (@test_deprecated get_bids(da_system, :price_sensitive_demand)) == price_sensitive_loads
+                    @test (@test_deprecated get_psds_per_bus(da_system)) == psls_per_bus
                 end
             end
 

--- a/test/system.jl
+++ b/test/system.jl
@@ -128,10 +128,10 @@
         pmax = time_series()
         pmin = time_series()
         pmax = time_series()
-        asm_regulation = services_time_series()
-        asm_spin = services_time_series()
-        asm_sup_on = services_time_series()
-        asm_sup_off = services_time_series()
+        regulation_offers = services_time_series()
+        spinning_offers = services_time_series()
+        on_supplemental_offers = services_time_series()
+        off_supplemental_offers = services_time_series()
 
         generator_time_series = GeneratorTimeSeries(;
             initial_generation,
@@ -140,10 +140,10 @@
             regulation_max,
             pmin,
             pmax,
-            asm_regulation,
-            asm_spin,
-            asm_sup_on,
-            asm_sup_off,
+            regulation_offers,
+            spinning_offers,
+            on_supplemental_offers,
+            off_supplemental_offers,
         )
 
         hours_at_status = KeyedArray(rand(length(ids)); ids)
@@ -226,10 +226,10 @@
                 @test get_regulation_min(system) == regulation_min
                 @test get_regulation_max(system) == regulation_max
 
-                @test skipmissing(get_regulation(system)) == skipmissing(asm_regulation)
-                @test skipmissing(get_spinning(system)) == skipmissing(asm_spin)
-                @test skipmissing(get_supplemental_on(system)) == skipmissing(asm_sup_on)
-                @test skipmissing(get_supplemental_off(system)) == skipmissing(asm_sup_off)
+                @test skipmissing(get_regulation_offers(system)) == skipmissing(regulation_offers)
+                @test skipmissing(get_spinning_offers(system)) == skipmissing(spinning_offers)
+                @test skipmissing(get_on_supplemental_offers(system)) == skipmissing(on_supplemental_offers)
+                @test skipmissing(get_off_supplemental_offers(system)) == skipmissing(off_supplemental_offers)
 
                 gens_by_zone = gens_per_zone(system)
                 @test issetequal(keys(gens_by_zone), [1, FullNetworkSystems.MARKET_WIDE_ZONE])
@@ -270,6 +270,11 @@
                     @test (@test_deprecated get_regmax(system)) == regulation_max
 
                     @test (@test_deprecated get_load(system)) == loads
+
+                    @test (@test_deprecated skipmissing(get_regulation(system))) == skipmissing(regulation_offers)
+                    @test (@test_deprecated skipmissing(get_spinning(system))) == skipmissing(spinning_offers)
+                    @test (@test_deprecated skipmissing(get_supplemental_on(system))) == skipmissing(on_supplemental_offers)
+                    @test (@test_deprecated skipmissing(get_supplemental_off(system))) == skipmissing(off_supplemental_offers)
                 end
             end
 

--- a/test/system.jl
+++ b/test/system.jl
@@ -223,8 +223,8 @@
                 @test get_offer_curve(system) == offer_curve
                 @test get_pmin(system) == pmin
                 @test get_pmax(system) == pmax
-                @test get_regmin(system) == regulation_min
-                @test get_regmax(system) == regulation_max
+                @test get_regulation_min(system) == regulation_min
+                @test get_regulation_max(system) == regulation_max
 
                 @test skipmissing(get_regulation(system)) == skipmissing(asm_regulation)
                 @test skipmissing(get_spinning(system)) == skipmissing(asm_spin)
@@ -265,6 +265,9 @@
 
                 @testset "deprecated" begin
                     @test (@test_deprecated get_lodf(system)) == lodfs
+
+                    @test (@test_deprecated get_regmin(system)) == regulation_min
+                    @test (@test_deprecated get_regmax(system)) == regulation_max
                 end
             end
 

--- a/test/system.jl
+++ b/test/system.jl
@@ -152,9 +152,9 @@
         da_generator_status = GeneratorStatusDA(; hours_at_status, availability, must_run)
 
         loads = time_series()
-        increment = offer_time_series()
-        decrement = offer_time_series()
-        price_sensitive_demand = offer_time_series()
+        increments = offer_time_series()
+        decrements = offer_time_series()
+        price_sensitive_demands = offer_time_series()
         da_system = SystemDA(;
             gens_per_bus,
             incs_per_bus,
@@ -170,9 +170,9 @@
             generator_time_series,
             generator_status=da_generator_status,
             loads,
-            increment,
-            decrement,
-            price_sensitive_demand,
+            increments,
+            decrements,
+            price_sensitive_demands,
         )
         @test da_system isa SystemDA
 
@@ -288,12 +288,18 @@
                 @test get_decs_per_bus(da_system) == decs_per_bus
                 @test get_psds_per_bus(da_system) == psds_per_bus
 
-                @test get_bids(da_system, :increment) == increment
-                @test get_bids(da_system, :decrement) == decrement
-                @test get_bids(da_system, :price_sensitive_demand) == price_sensitive_demand
+                @test get_increments(da_system) == increments
+                @test get_decrements(da_system) == decrements
+                @test get_price_sensitive_demands(da_system) == price_sensitive_demands
 
                 @test get_availability(da_system) == availability
                 @test get_must_run(da_system) == must_run
+
+                @testset "deprecated" begin
+                    @test (@test_deprecated get_bids(da_system, :increment)) == increments
+                    @test (@test_deprecated get_bids(da_system, :decrement)) == decrements
+                    @test (@test_deprecated get_bids(da_system, :price_sensitive_demand)) == price_sensitive_demands
+                end
             end
 
             @testset "SystemRT only accessors" begin

--- a/test/system.jl
+++ b/test/system.jl
@@ -176,9 +176,9 @@
         )
         @test da_system isa SystemDA
 
-        status = time_series(Bool)
-        status_regulation = time_series(Bool)
-        rt_generator_status = GeneratorStatusRT(; status, status_regulation)
+        commitment = time_series(Bool)
+        regulation_commitment= time_series(Bool)
+        rt_generator_status = GeneratorStatusRT(; commitment, regulation_commitment)
 
         rt_system = SystemRT(;
             gens_per_bus,
@@ -290,8 +290,8 @@
             end
 
             @testset "SystemRT only accessors" begin
-                @test get_commitment(rt_system) == status
-                @test get_regulation_commitment(rt_system) == status_regulation
+                @test get_commitment(rt_system) == commitment
+                @test get_regulation_commitment(rt_system) == regulation_commitment
             end
         end
     end


### PR DESCRIPTION
- resolves #23 
- also closes #25 since that fits well with the renaming
- no version bump as this to be part of the same release as #19 which added the keyword constructors and so made the fieldnames public API