### PR TITLE
Reverting change to `branches_by_breakpoints`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FullNetworkSystems"
 uuid = "877b7152-b508-43dc-81fb-72341a693988"
 authors = ["Invenia Technical Computing Corporation"]
-version = "1.5.0"
+version = "1.5.1"
 
 [deps]
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -138,17 +138,17 @@ function gens_per_zone(system::System)
 end
 
 """
-    branches_by_breakpoints(system::System) -> NTuple{3, Vector{$BranchName}}
+    branches_by_breakpoints(system::System)
 
 Returns three vectors containing of the names of branches which have 0, 1, and 2 breakpoints.
 """
 function branches_by_breakpoints(system::System)
-    zero_bp, one_bp, two_bp = BranchName[], BranchName[], BranchName[]
+    zero_bp, one_bp, two_bp = String[], String[], String[]
     for branch in system.branches
         if branch.is_monitored
-            if all(iszero, branch.break_points)
+            if all(branch.break_points .== 0.0)
                 push!(zero_bp, branch.name)
-            elseif iszero(last(branch.break_points))
+            elseif last(branch.break_points) == 0.0
                 push!(one_bp, branch.name)
             else
                 push!(two_bp, branch.name)

--- a/test/system.jl
+++ b/test/system.jl
@@ -243,11 +243,10 @@
                     @test v == gen_ids
                 end
 
-                zero_bp, one_bp, two_bp = branches_by_breakpoints(system)
+                zero_bp, one_bp, two_bp = branches_by_breakpoints(da_system)
                 @test zero_bp == ["3"]
-                @test one_bp == [] # unmonitored
+                @test one_bp == String[] #unmonitored
                 @test two_bp == ["1", "4"]
-                @test eltype(zero_bp) == eltype(one_bp) == eltype(two_bp) == FullNetworkSystems.BranchName
 
                 # Also test on a system with a 1-breakpoint branch
                 da_system.branches = Dictionary(


### PR DESCRIPTION
Reverting this change to `branches_by_breakpoints` as a temporary fix for String/InlineString mismatches in simulations.  The proper fix has been merge to JuMP and will be in the next release: https://github.com/jump-dev/JuMP.jl/pull/3028#issuecomment-1198729548

We should restore these changes when that JuMP release lands (https://github.com/invenia/FullNetworkSystems.jl/issues/29)