### PR TITLE
RFC: Define AncillaryServices types to support different sets of ancillary services

### DIFF
--- a/src/FullNetworkSystems.jl
+++ b/src/FullNetworkSystems.jl
@@ -10,7 +10,10 @@ using SparseArrays
 
 export System, SystemDA, SystemRT
 export Zone, Generator, Bus, Branch
-export Zones, Generators, Buses, Branches
+export SystemRequirements, ZonalRequirements, SystemWideRequirements
+export Generators, Buses, Branches
+export AncillaryServices, FourServices, FiveServices
+export LoadTimeSeries
 export GeneratorTimeSeries, GeneratorStatus, GeneratorStatusDA, GeneratorStatusRT
 export gens_per_zone, branches_by_breakpoints, get_datetimes
 export get_zones, get_buses, get_generators, get_branches, get_lines, get_transformers

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -8,28 +8,38 @@ function get_datetimes(system::System)
     return axiskeys(system.generator_time_series.offer_curve, 2)
 end
 
-get_zones(system::System) = system.zones
+
+get_system_requirements(system::SystemDA) = system.requirements
 
 "Returns a `Dictionary` with zonal regulation requirements indexed by zone number."
-function get_regulation_requirements(system::System)
-    return map(system.zones) do zone
+function get_regulation_requirements(requirements::ZonalRequirements)
+    return map(requirements) do zone
         zone.regulation
     end
 end
 
 "Returns a `Dictionary` with zonal operating reserve requirements indexed by zone number."
-function get_operating_reserve_requirements(system::System)
-    return map(system.zones) do zone
+function get_operating_reserve_requirements(requirements::ZonalRequirements)
+    return map(requirements) do zone
         zone.operating_reserve
     end
 end
 
 "Returns a `Dictionary` with zonal good utility practice requirements indexed by zone number."
-function get_good_utility_requirements(system::System)
-    return map(system.zones) do zone
+function get_good_utility_requirements(requirements::ZonalRequirements)
+    return map(requirements) do zone
         zone.good_utility
     end
 end
+
+get_regulation_up_requirement(requirements::SystemWideRequirements) = requirements.regulation_up
+
+get_regulation_down_requirement(requirements::SystemWideRequirements) = requirements.regulation_down
+
+get_responsive_requirement(requirements::SystemWideRequirements) = requirements.responsive_regulation
+
+get_non_spinning_requirement(requirements::SystemWideRequirements) = requirements.non_spinning
+
 
 "Returns a `Dictionary` of `Bus` objects in the `System` indexed by bus name."
 get_buses(system::System) = system.buses
@@ -58,7 +68,7 @@ get_lodfs(system::System) = system.lodfs
 "Returns the generation of the generator at the start of the time period (pu)"
 get_initial_generation(system::System) = system.generator_time_series.initial_generation
 "Returns time series data of the fixed loads in the system"
-get_loads(system::System) = system.loads
+get_fixed_loads(system::System) = system.loads
 "Returns time series data of the generator offer curves"
 get_offer_curve(system::System) = system.generator_time_series.offer_curve
 "Returns time series data of minimum generator output (pu)"
@@ -70,14 +80,34 @@ get_regulation_min(system::System) = system.generator_time_series.regulation_min
 "Returns time series data of maximum generator output in the ancillary services market (pu)"
 get_regulation_max(system::System) = system.generator_time_series.regulation_max
 
+
+get_ancillary_services(system::SystemDA) = system.generator_time_series.ancillary_services
+
 "Returns time series data of offer prices for ancillary servives regulation reserves (\$ /pu)"
-get_regulation_offers(system::System) = system.generator_time_series.regulation_offers
+get_regulation_offers(ancillary_services::FourServices) = ancillary_services.regulation_offers
 "Returns time series data of offer prices for ancillary servives spinning reserves (\$ /pu)"
-get_spinning_offers(system::System) = system.generator_time_series.spinning_offers
+get_spinning_offers(ancillary_services::FourServices) = ancillary_services.spinning_offers
 "Returns time series data of offer prices for ancillary servives online supplemental reserves (\$ /pu)"
-get_on_supplemental_offers(system::System) = system.generator_time_series.on_supplemental_offers
+get_on_supplemental_offers(ancillary_services::FourServices) = ancillary_services.on_supplemental_offers
 "Returns time series data of offer prices for ancillary servives offline supplemental reserves (\$ /pu)"
-get_off_supplemental_offers(system::System) = system.generator_time_series.off_supplemental_offers
+get_off_supplemental_offers(ancillary_services::FourServices) = ancillary_services.off_supplemental_offers
+
+get_regulation_up_offers(ancillary_services::FiveServices) = ancillary_services.regulation_up_offers
+
+get_regulation_down_offers(ancillary_services::FiveServices) = ancillary_services.regulation_down_offers
+
+get_responsive_regulation_offers(ancillary_services::FiveServices) = ancillary_services.responsive_regulation_offers
+
+get_on_nonspinning_offers(ancillary_services::FiveServices) = ancillary_services.on_nonspinning_offers
+
+get_off_nonspinning_offers(ancillary_services::FiveServices) = ancillary_services.off_nonspinning_offers
+
+
+get_load_pmin(load_timeseries::LoadTimeSeries) = load_timeseries.pmin
+
+get_load_pmax(load_timeseries::LoadTimeSeries) = load_timeseries.pmax
+
+get_load_ancillary_services(system::SystemDA) = system.load_services.ancillary_services
 
 "Returns a flag indicating whether each generator was on at the start of the day."
 function get_initial_commitment(system::SystemDA)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -30,3 +30,13 @@ function get_bids(system::SystemDA, type_of_bid::Symbol)
         return getproperty(system, type_of_bid)
     end
 end
+
+@deprecate get_regulation_offers(system::System) get_regulation_offers(get_ancillary_services(system))
+@deprecate get_spinning_offers(system::System) get_spinning_offers(get_ancillary_services(system))
+@deprecate get_on_supplemental_offers(system::System) get_on_supplemental_offers(get_ancillary_services(system))
+@deprecate get_off_supplemental_offers(system::System) get_off_supplemental_offers(get_ancillary_services(system))
+
+@deprecate get_zones(system::System) get_requirements(system)
+@deprecate get_regulation_requirements(system::System) get_regulation_requirements(get_requirements(system))
+@deprecate get_operating_reserve_requirements(system::System) get_operating_reserve_requirements(get_requirements(system))
+@deprecate get_good_utility_requirements(system::System) get_good_utility_requirements(get_requirements(system))


### PR DESCRIPTION
Different markets have different sets of ancillary services and related ancillary service requirements.  

Let's assume we want one `SystemDA` type to support multiple markets.  The proposal here is to define a type hierarchy for ancillary services that allows us to represent the different ancillary service markets.  But this causes a potential difficulty with the accessor functions, because instances of `System` with different types of `AncillaryServices` won't have certain ancillary service fields. 

The solution to that issue is to have a single accessor for the user to get the ancillary services from the `System`.  Then each `AncillaryServices` subtype has its own set of accessors.

Example: accessing the regulation offers
```julia
# currently - a single accessor acting on `System`
get_regulation_offers(system::System) = system.generator_time_series.regulation_offers

# proposal - the user needs two accessors - one to get AncillaryServices - then another to get the regulation offers
get_ancillary_services(system::System) = system.generator_time_series.ancillary_services
get_regulation_offers(as_offers::FourServices) = as_offers.regulation_offers
```