### PR TITLE
Add technology type

### DIFF
--- a/src/FullNetworkSystems.jl
+++ b/src/FullNetworkSystems.jl
@@ -11,6 +11,7 @@ using SparseArrays
 export System, SystemDA, SystemRT
 export Zone, Generator, Bus, Branch
 export Zones, Generators, Buses, Branches
+export SingleCycle, CombinedCycle
 export GeneratorTimeSeries, GeneratorStatus, GeneratorStatusDA, GeneratorStatusRT
 export gens_per_zone, branches_by_breakpoints, get_datetimes
 export get_zones, get_buses, get_generators, get_branches, get_lines, get_transformers

--- a/src/FullNetworkSystems.jl
+++ b/src/FullNetworkSystems.jl
@@ -25,7 +25,7 @@ export get_initial_generation, get_loads, get_offer_curve
 export get_pmin, get_pmax, get_regulation_min, get_regulation_max
 export get_regulation_offers, get_spinning_offers, get_on_supplemental_offers, get_off_supplemental_offers
 export get_commitment, get_regulation_commitment
-export get_technologies, ccgs_per_parent
+export get_technologies, get_fuel_type, ccgs_per_parent
 
 include("system.jl")
 include("accessors.jl")

--- a/src/FullNetworkSystems.jl
+++ b/src/FullNetworkSystems.jl
@@ -25,6 +25,7 @@ export get_initial_generation, get_loads, get_offer_curve
 export get_pmin, get_pmax, get_regulation_min, get_regulation_max
 export get_regulation_offers, get_spinning_offers, get_on_supplemental_offers, get_off_supplemental_offers
 export get_commitment, get_regulation_commitment
+export get_technologies, ccgs_per_parent
 
 include("system.jl")
 include("accessors.jl")

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -128,7 +128,7 @@ get_regulation_commitment(system::SystemRT) = system.generator_status.regulation
 Returns a `Dict` with keys of `Zone` numbers and values of generator names in that zone.
 """
 function gens_per_zone(system::System)
-    gens_per_zone = Dict{Int, Vector{Int}}()
+    gens_per_zone = Dict{Int, Vector{GenId}}()
     for gen in system.generators
         if haskey(gens_per_zone, gen.zone)
             push!(gens_per_zone[gen.zone], gen.unit_code)

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -122,6 +122,23 @@ get_commitment(system::SystemRT) = system.generator_status.commitment
 "Returns time series data of generator regulation commitment status in each hour"
 get_regulation_commitment(system::SystemRT) = system.generator_status.regulation_commitment
 
+"Returns a `Dictionary` of `Technology`s indexed by Generator ID"
+get_technologies(system::System) = map(gen -> gen.technology, get_generators(system))
+
+"Returns all CombinedCycle generator configuration IDs keyed by the source generator"
+function ccgs_per_parent(system::System)
+    ccgs = Dict{GenId, Vector{GenId}}()
+
+    for gen in system.generators
+        gen.technology isa CombinedCycle || continue
+
+        config = get!(ccgs, gen.technology.parent, GenId[])
+        push!(config, gen.unit_code)
+    end
+
+    return ccgs
+end
+
 """
     gens_per_zone(system::System)
 

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -124,6 +124,8 @@ get_regulation_commitment(system::SystemRT) = system.generator_status.regulation
 
 "Returns a `Dictionary` of `Technology`s indexed by Generator ID"
 get_technologies(system::System) = map(gen -> gen.technology, get_generators(system))
+"Returns a `Dictionary` of `Symbol`s describing generator fuel types indexed by Generator ID"
+get_fuel_type(system::System) = map(gen -> gen.technology.fuel_type, get_generators(system))
 
 "Returns all CombinedCycle generator configuration IDs keyed by the source generator"
 function ccgs_per_parent(system::System)

--- a/src/system.jl
+++ b/src/system.jl
@@ -25,6 +25,47 @@ end
 const Zones = Dictionary{ZoneNum, Zone}
 
 const UnitCode = Int64
+const GenId = Union{UnitCode, InlineString31}
+
+"""
+    $TYPEDEF
+
+Abstract type to describe generation-specific internals of generators.
+"""
+abstract type Technology end
+
+"""
+    $TYPEDEF
+
+Type to describe a single configuration of a combined cycle generator.
+
+Fields:
+$TYPEDFIELDS
+"""
+Base.@kwdef struct CombinedCycle <: Technology
+    "Id linking back to the resource this configuration is from"
+    parent::GenId
+    "Symbol describing the technology of the generator"
+    fuel_type::Symbol
+end
+# Handle string conversion
+CombinedCycle(parent::AbstractString, args...) = CombinedCycle(InlineString31(parent), args...)
+
+"""
+    $TYPEDEF
+
+Type to describe a generator with no alternate configurations.
+
+Fields:
+$TYPEDFIELDS
+"""
+Base.@kwdef struct SingleCycle <: Technology
+    "Symbol describing the technology of the generator"
+    fuel_type::Symbol
+end
+# Fall back to SingleCycle to avoid breaking change
+Base.convert(::Type{Technology}, fuel_type::Symbol) = SingleCycle(fuel_type)
+
 """
     $TYPEDEF
 
@@ -36,7 +77,7 @@ $TYPEDFIELDS
 """
 Base.@kwdef struct Generator
     "Generator id/unit code"
-    unit_code::UnitCode
+    unit_code::GenId
     "Number of the zone the generator is located in"
     zone::Int
     "Cost of turning on the generator (\$)"
@@ -53,10 +94,13 @@ Base.@kwdef struct Generator
     ramp_up::Float64
     "Rate at which the generator can decrease generation (pu/minute)"
     ramp_down::Float64
-    "Symbol describing the technology of the generator"
-    technology::Symbol
+    "Type describing the technology of the generator"
+    technology::Technology
 end
-const Generators = Dictionary{UnitCode, Generator}
+# Handle string conversion
+Generator(unit_code::AbstractString, args...) = Generator(InlineString31(unit_code), args...)
+
+const Generators = Dictionary{GenId, Generator}
 
 const BusName = InlineString15
 """

--- a/src/system.jl
+++ b/src/system.jl
@@ -25,7 +25,7 @@ end
 const Zones = Dictionary{ZoneNum, Zone}
 
 const UnitCode = Int64
-const GenId = Union{UnitCode, InlineString31}
+const GenId = InlineString31
 
 """
     $TYPEDEF
@@ -48,8 +48,6 @@ Base.@kwdef struct CombinedCycle <: Technology
     "Symbol describing the technology of the generator"
     fuel_type::Symbol
 end
-# Handle string conversion
-CombinedCycle(parent::AbstractString, args...) = CombinedCycle(InlineString31(parent), args...)
 
 """
     $TYPEDEF
@@ -97,8 +95,6 @@ Base.@kwdef struct Generator
     "Type describing the technology of the generator"
     technology::Technology
 end
-# Handle string conversion
-Generator(unit_code::AbstractString, args...) = Generator(InlineString31(unit_code), args...)
 
 const Generators = Dictionary{GenId, Generator}
 
@@ -386,7 +382,7 @@ $TYPEDFIELDS
 """
 Base.@kwdef mutable struct SystemDA <: System
     "`Dictionary` where the keys are bus names and the values are generator ids at that bus"
-    gens_per_bus::Dictionary{BusName, Vector{Int}}
+    gens_per_bus::Dictionary{BusName, Vector{GenId}}
     "`Dictionary` where the keys are bus names and the values are increment bid ids at that bus"
     incs_per_bus::Dictionary{BusName, Vector{BidName}}
     "`Dictionary` where the keys are bus names and the values are decrement bid ids at that bus"
@@ -448,10 +444,9 @@ $TYPEDFIELDS
 """
 Base.@kwdef mutable struct SystemRT <: System
     "`Dictionary` where the keys are bus names and the values are generator ids at that bus"
-    gens_per_bus::Dictionary{BusName, Vector{Int}}
+    gens_per_bus::Dictionary{BusName, Vector{GenId}}
     "`Dictionary` where the keys are bus names and the values are load ids at that bus"
     loads_per_bus::Dictionary{BusName, Vector{BidName}}
-
     "Zones in the `System`, which will also include a `Zone` entry for the market wide zone"
     zones::Zones
     "Buses in the `System` indexed by bus name"

--- a/test/system.jl
+++ b/test/system.jl
@@ -100,8 +100,8 @@
             Generator(id, zone1.number, 0.0, 1.0, 1.0, 24.0, 24.0, 2.0, 2.0, :tech)
         end
 
-        ccg1_tech = CombinedCycle("1", :tech)
-        ccg2_tech = CombinedCycle("2", :tech)
+        ccg1_tech = CombinedCycle("1", :tech2)
+        ccg2_tech = CombinedCycle("2", :tech2)
         combined_gen_types = [
             Generator("116", zone1.number, 0.0, 1.0, 1.0, 24.0, 24.0, 2.0, 2.0, ccg1_tech)
             Generator("117", zone1.number, 0.0, 1.0, 1.0, 24.0, 24.0, 2.0, 2.0, ccg1_tech)
@@ -251,6 +251,9 @@
                     fill(ccg2_tech, 2)
                 )
                 @test get_technologies(system) == Dictionary(gen_ids, expected_tech)
+                @test get_fuel_type(system) == Dictionary(
+                    gen_ids, repeat([:tech, :tech2], inner=5)
+                )
                 @test ccgs_per_parent(system) == Dict(
                     "1" => ["116", "117", "118"], "2" => ["119", "120"],
                 )

--- a/test/system.jl
+++ b/test/system.jl
@@ -6,22 +6,8 @@
     end
 
     @testset "Generator" begin
-        gen1 = Generator(
-            unit_code=111,
-            zone=1,
-            startup_cost=0.0,
-            shutdown_cost=1.0,
-            no_load_cost=1.0,
-            min_uptime=24.0,
-            min_downtime=24.0,
-            ramp_up=2.0,
-            ramp_down=2.0,
-            technology=:tech
-        )
-        @test gen1 isa Generator
-
         gen2 = Generator(
-            unit_code="Gen2",
+            unit_code="Gen1",
             zone=1,
             startup_cost=0.0,
             shutdown_cost=1.0,
@@ -34,25 +20,8 @@
         )
         @test gen2 isa Generator
 
-        gen3 = Generator(
-            unit_code="Gen3",
-            zone=1,
-            startup_cost=0.0,
-            shutdown_cost=1.0,
-            no_load_cost=1.0,
-            min_uptime=24.0,
-            min_downtime=24.0,
-            ramp_up=2.0,
-            ramp_down=2.0,
-            technology=CombinedCycle(
-                parent=111,
-                fuel_type=:tech,
-            ),
-        )
-        @test gen3 isa Generator
-
-        gen4 = Generator(
-            unit_code="Gen3",
+        gen2 = Generator(
+            unit_code="Gen2",
             zone=1,
             startup_cost=0.0,
             shutdown_cost=1.0,
@@ -66,7 +35,7 @@
                 fuel_type=:tech,
             ),
         )
-        @test gen4 isa Generator
+        @test gen2 isa Generator
     end
 
     @testset "Bus" begin
@@ -126,7 +95,7 @@
         zone_market = Zone(-9999, 3.0, 3.0, 3.0)
         zones = Dictionary([1, 2, -9999], [zone1, zone2, zone_market])
 
-        gen_ids = collect(111:1:120)
+        gen_ids = string.(111:1:120)
         gen_types = map(gen_ids) do id
             Generator(id, zone1.number, 0.0, 1.0, 1.0, 24.0, 24.0, 2.0, 2.0, :tech)
         end

--- a/test/system.jl
+++ b/test/system.jl
@@ -19,6 +19,54 @@
             technology=:tech
         )
         @test gen1 isa Generator
+
+        gen2 = Generator(
+            unit_code="Gen2",
+            zone=1,
+            startup_cost=0.0,
+            shutdown_cost=1.0,
+            no_load_cost=1.0,
+            min_uptime=24.0,
+            min_downtime=24.0,
+            ramp_up=2.0,
+            ramp_down=2.0,
+            technology=SingleCycle(fuel_type=:tech)
+        )
+        @test gen2 isa Generator
+
+        gen3 = Generator(
+            unit_code="Gen3",
+            zone=1,
+            startup_cost=0.0,
+            shutdown_cost=1.0,
+            no_load_cost=1.0,
+            min_uptime=24.0,
+            min_downtime=24.0,
+            ramp_up=2.0,
+            ramp_down=2.0,
+            technology=CombinedCycle(
+                parent=111,
+                fuel_type=:tech,
+            ),
+        )
+        @test gen3 isa Generator
+
+        gen4 = Generator(
+            unit_code="Gen3",
+            zone=1,
+            startup_cost=0.0,
+            shutdown_cost=1.0,
+            no_load_cost=1.0,
+            min_uptime=24.0,
+            min_downtime=24.0,
+            ramp_up=2.0,
+            ramp_down=2.0,
+            technology=CombinedCycle(
+                parent="ParentGen",
+                fuel_type=:tech,
+            ),
+        )
+        @test gen4 isa Generator
     end
 
     @testset "Bus" begin


### PR DESCRIPTION
A first stab at https://github.com/invenia/FullNetworkSystems.jl/issues/9

Extends generator `technology` to account for multiple Combined Cycle configurations and allows use of string identifiers.