### PR TITLE
Fix branch referenced for stable docs build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
   push:
     branches: [main]
-    tags: "*"
+    tags: ["*"]
   pull_request:
 jobs:
   test:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,11 +1,11 @@
 name: CI
-# Run on master, tags, or any pull request
+# Run on main, tags, or any pull request
 on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
   push:
-    branches: [master]
-    tags: ["*"]
+    branches: [main]
+    tags: "*"
   pull_request:
 jobs:
   test:


### PR DESCRIPTION
The CI workflow was previously referencing `master` instead of `main`.  I am hoping changing this will fix the stable docs build, which is currently broken.